### PR TITLE
Fix for Angular 9

### DIFF
--- a/src/ngx-barcode.component.ts
+++ b/src/ngx-barcode.component.ts
@@ -33,7 +33,7 @@ export class NgxBarcodeComponent implements OnChanges {
   @Input('bc-margin-left') marginLeft = 10;
   @Input('bc-margin-right') marginRight = 10;
   @Input('bc-value') value = '';
-  @ViewChild('bcElement') bcElement: ElementRef;
+  @ViewChild('bcElement', {static: true}) bcElement: ElementRef;
 
   @Input('bc-valid') valid: () => boolean = () => true;
 


### PR DESCRIPTION
this.bcElement is undefined in Angular 9, setting the viewchild to static: true fixes this.